### PR TITLE
Add ()'s around 'and' action in ast2peg and update tests so they all …

### DIFF
--- a/parser-gen.lua
+++ b/parser-gen.lua
@@ -53,7 +53,6 @@ local function resetOptions()
   return opts
 end
 
-
 -- check values and fill default to the opts 
 local function mergeOptions(options)
 
@@ -81,9 +80,7 @@ local function mergeOptions(options)
 -- Lua 5.1 compatibility:
   local unpack = unpack or table.unpack
 
-
   local Predef = { nl = m.P"\n", cr = m.P"\r", tab = m.P"\t" }
-
 
   local function updatelocale()
     m.locale(Predef)
@@ -112,19 +109,13 @@ local function mergeOptions(options)
 
   updatelocale()
 
-
-
   local function defaultsync(patt)
     return (m.P(1)^-1) * (-patt * m.P(1))^0
   end
 
-
-
-
   local function sync (patt)
     return patt --(-patt * m.P(1))^0 * patt^0 -- skip until we find the pattern and consume it(if we do)
   end
-
 
   local function pattspaces (patt)
     if opts.skipspaces then
@@ -149,7 +140,6 @@ local function mergeOptions(options)
   end
 
   local bg = {} -- local variable to keep global function buildgrammar
-
 
   local function addspaces (caps)
     local hastoken = tokenstack:pop()
@@ -274,7 +264,6 @@ local function mergeOptions(options)
     end
   end
 
-
   local function applygrammar(gram, opts)
     if opts.trace then 
       return m.P(pegdebugtrace(gram, opts.traceoptions))
@@ -306,7 +295,6 @@ local function mergeOptions(options)
 
       ret1 = traverse(op1, tokenrule)
       ret2 = traverse(op2, tokenrule)
-
 
       return applyaction(act, ret1, ret2, tokenrule)
 
@@ -405,7 +393,6 @@ local function mergeOptions(options)
     end
   end
 
-
   function bg.buildgrammar (ast)
     local builder = {}
 
@@ -449,9 +436,6 @@ local function mergeOptions(options)
 
     return builder
   end
-
-
-
 
   local function build(ast, opts)
 
@@ -508,7 +492,7 @@ local function mergeOptions(options)
     if action == "or" then
       return '(' .. op1 ..' / '.. op2 ..')'
     elseif action == "and" then
-      return op1 ..' ' .. op2
+      return '('..op1..' '..op2..')'  --25/04/24 DCN: added brackets
     elseif action == "&" then
       return '&'..op1
     elseif action == "!" then
@@ -526,7 +510,7 @@ local function mergeOptions(options)
 --		if not lab then
 --			error("Label '"..op2.."' unspecified using setlabels()")
 -- end
-      return op1 .. '^'..op2 
+      return op1..'^'..op2
     elseif action == "->" then
       if op1 == "''" then -- spacial case for empty capture
         return  op1 ..' -> '.. op2  
@@ -726,7 +710,6 @@ local function mergeOptions(options)
     if opts.recovery and not  builder["SYNC"] then 
       builder["SYNC"] = opts.specialrules.SYNC_re
     end
-
 
   end  
 

--- a/peg-parser-tests.lua
+++ b/peg-parser-tests.lua
@@ -4,6 +4,7 @@ local f = peg.pegToAST
 local eq = require "equals"
 local equals = eq.equals
 
+local serpent = pcall(require, "serpent") and require "serpent" or function(...) print(...)  end
 
 -- self-description of peg-parser:
 
@@ -12,7 +13,6 @@ local equals = eq.equals
 -- ( p )	grouping
 e = f("('a')")
 res = {t="a"}
-
 assert(equals(e,res))
 
 -- 'string'	literal string
@@ -24,95 +24,93 @@ assert(equals(e,res))
 -- "string"	literal string
 e = f('"string"')
 res = {t="string"}
-
 assert(equals(e,res))
+
 --[class]	character class
 e = f("[^a-zA-Z01]")
 res = {
-	action = "invert",
+	action = "class",
 	op1 = {
-		action = "or",
+		action = "invert",
 		op1 = {
-			action = "or",
+			action = "classset",
 			op1 = {
-				action = "or",
+				action = "classset",
 				op1 = {
-					action = "range",
+					action = "classset",
 					op1 = {
-						s = "az"
+						action = "range",
+						op1 = {
+							name = "az"
+						}
+					},
+					op2 = {
+						action = "range",
+						op1 = {
+							name = "AZ"
+						}
 					}
 				},
 				op2 = {
-					action = "range",
-					op1 = {
-						s = "AZ"
-					}
+					tchar = "0"
 				}
 			},
 			op2 = {
-				t = "0"
+				tchar = "1"
 			}
-		},
-		op2 = {
-			t = "1"
 		}
 	}
-}	 
+}
 
+print('\nast:\n')
+print(serpent.block(e))
+print('')
 
 assert(equals(e,res))
 
 --.	any character
 e = f(".")
 res = {action="anychar"}
-
 assert(equals(e,res))
+
 --%name	pattern defs[name] or a pre-defined pattern
 e = f("%name")
-res = {action="%", op1={s="name"}}
-
+res = {action="%", op1={name="name"}}
 assert(equals(e,res))
+
 --name	non terminal
 e = f("name")
 res = {nt="name"}
-
 assert(equals(e,res))
 
 --<name>	non terminal
 e = f("<name>")
 res = {nt="name"}
-
 assert(equals(e,res))
 
 --{}	position capture
 e = f("{}")
-
 res = {action="poscap"}
-
 assert(equals(e,res))
 
 --{ p }	simple capture
 e = f("{name}")
 res = {action="scap", op1= {nt="name"}}
-
 assert(equals(e,res))
 
 --{: p :}	anonymous group capture
 e = f("{:name:}")
 res = {action="gcap", op1= {nt="name"}}
-
 assert(equals(e,res))
 
 --{:name: p :}	named group capture
 e = f("{:g: name:}")
-res = {action="gcap", op1= {nt="name"} , op2={s="g"}}
-
+res = {action="gcap", op1= {nt="name"} , op2={name="g"}}
 assert(equals(e,res))
+
 --{~ p ~}	substitution capture
 e = f("{~ name ~}")
-
 res = {action="subcap", op1= {nt="name"}}
-
 assert(equals(e,res))
 
 --{| p |}	table capture
@@ -122,7 +120,7 @@ assert(equals(e,res))
 
 --=name	back reference
 e = f("=name")
-res = {action="bref", op1= {s="name"}}
+res = {action="bref", op1= {name="name"}}
 assert(equals(e,res))
 
 --p ?	optional match
@@ -157,7 +155,7 @@ assert(equals(e,res))
 
 --p^LABEL error label
 e = f("name^err")
-res = {action = "^LABEL", op1= {nt="name"}, op2 = {s="err"}}
+res = {action = "^LABEL", op1= {nt="name"}, op2 = {name="err"}}
 assert(equals(e,res))
 
 --p -> 'string'	string capture
@@ -171,70 +169,46 @@ res = {action="->", op1= {nt="name"}, op2 = {s="a"}}
 assert(equals(e,res))
 
 --p -> num	numbered capture
-
 e = f('name -> 3')
-
 res = {action="->", op1= {nt="name"}, op2 = {num="3"}}
-
 assert(equals(e,res))
 
 --p -> name	function/query/string capture equivalent to p / defs[name]
-
 e = f('name -> func')
 res = {action="->", op1= {nt="name"}, op2 = {func="func"}}
-
 assert(equals(e,res))
-
-
 
 --p => name	match-time capture equivalent to lpeg.Cmt(p, defs[name])
-
 e = f('name => func')
 res = {action="=>", op1= {nt="name"}, op2 = {func="func"}}
-
 assert(equals(e,res))
 
-
---& p	and predicate
-
+--& p   and predicate
 e = f('&name')
 res = {action="&", op1= {nt="name"}}
-
 assert(equals(e,res))
-
 
 --! p	not predicate
-
-
 e = f('!name')
 res = {action="!", op1= {nt="name"}}
-
 assert(equals(e,res))
 
-
 --p1 p2 p3	concatenation with left association
-
 e = f('name name2 name3')
 res = {action="and", op1= {action = "and", op1={nt="name"}, op2={nt="name2"}}, op2={nt="name3"}}
-
 assert(equals(e,res))
 
 --p1 / p2 / p3	ordered choice with left association
-
 e = f('name / name2 / name3')
 res = {action="or", op1= {action = "or", op1={nt="name"}, op2={nt="name2"}}, op2={nt="name3"}}
-
 assert(equals(e,res))
 
-
 --(name <- p)+	grammar
-
 e = f('a <- b b <- c')
 res = {
 	{rulename = "a", rule = {nt="b"}},
 	{rulename = "b", rule = {nt="c"}}
 }
-
 assert(equals(e,res))
 
 -- error labels
@@ -242,19 +216,14 @@ assert(equals(e,res))
 
 --peg.setlabels({errName=1})
 e = f('%{errName}')
-
-res = {action="label", op1={s="errName"}}
-
+res = {action="label", op1={name="errName"}}
 assert(equals(e,res))
 
 -- a //{errName,errName2} b
 
 --peg.setlabels({errName=1, errName2=2})
 e = f('a ^errName')
-
-res = {action="^LABEL", op2={s="errName"}, op1={nt="a"}}
-
-
+res = {action="^LABEL", op2={name="errName"}, op1={nt="a"}}
 assert(equals(e,res))
 
 print("all tests succesful")


### PR DESCRIPTION
a simple peg of "exp <- 'a' ('/' 'b')*" failed the peg->ast->peg round trip due to function applyActionAstToPEG not putting ()'s around its op1 and op2 terms.
peg-parser tests have also been updated to reflect the modified re-grammar so they all pass